### PR TITLE
feat: save notes with local storage + fix bringToFront

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import { useEffect } from 'react';
 import { DndContext, DragEndEvent } from '@dnd-kit/core';
 import { PlusCircle } from 'lucide-react';
 import { Note } from './components/Note';
 import { useNotesStore } from './store';
+import updateNotesFromLocalStorage from './utils/updateNotesFromLocalStorage';
 
 function App() {
-  const { notes, addNote, updateNote, updatePosition, deleteNote } = useNotesStore();
+  const { notes, addNote, updateNote, updatePosition, deleteNote, bringToFront } = useNotesStore();
+
+  useEffect(() => updateNotesFromLocalStorage(notes), [notes]);
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, delta } = event;
@@ -35,6 +38,7 @@ function App() {
             note={note}
             onUpdate={(content) => updateNote(note.id, content)}
             onDelete={() => deleteNote(note.id)}
+            onBringToFront={() => bringToFront(note.id)}
           />
         ))}
       </DndContext>

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import getNotesFromLocalStorage from './utils/getNotesFromLocalStorage';
 
 export interface Note {
   id: string;
@@ -20,7 +21,7 @@ interface NotesStore {
 const colors = ['yellow', 'pink', 'blue', 'green', 'purple'];
 
 export const useNotesStore = create<NotesStore>((set) => ({
-  notes: [],
+  notes: getNotesFromLocalStorage(),
   addNote: () => set((state) => ({
     notes: [...state.notes, {
       id: crypto.randomUUID(),

--- a/src/utils/getNotesFromLocalStorage.ts
+++ b/src/utils/getNotesFromLocalStorage.ts
@@ -1,0 +1,27 @@
+import { Note } from "../store";
+
+function getNotesFromLocalStorage() {
+    const key = "sagestickynotes";
+    let data = localStorage.getItem(key);
+
+    if (!data) {
+      const emptyList: Note[] = [];
+      localStorage.setItem(key, JSON.stringify(emptyList));
+      return emptyList;
+    }
+
+    try {
+      const notes: Note[] = JSON.parse(data);
+      if (!Array.isArray(notes)) {
+        console.error("The content of sagestickynotes is not an array.");
+        return [];
+      }
+
+      return notes;
+    } catch (e) {
+      console.error("Error while parsing JSON:", e);
+      return [];
+    }
+}
+
+export default getNotesFromLocalStorage;

--- a/src/utils/updateNotesFromLocalStorage.ts
+++ b/src/utils/updateNotesFromLocalStorage.ts
@@ -1,0 +1,8 @@
+import { Note } from "../store";
+
+function updateNotesFromLocalStorage(notes: Note[]) {
+    const key = "sagestickynotes";
+    localStorage.setItem(key, JSON.stringify(notes));
+}
+
+export default updateNotesFromLocalStorage;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

1. Notes are automatically saved in the local storage.
2. Use the bringToFront method of the store to be able to put a note in front of the others notes.

## QA Instructions, Screenshots, Recordings

1. Check that the changes persist even after refreshing the page or navigating away.
2. Ensure that notes are correctly brought to the front when using the bringToFront method and that they overlay other notes properly.
